### PR TITLE
Ember 2.0 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-release
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/bower.json
+++ b/bower.json
@@ -1,19 +1,22 @@
 {
   "name": "ember-bug-widget",
   "dependencies": {
-    "ember": "1.13.8",
+    "ember": "2.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "0.1.3",
-    "ember-data": "1.13.8",
+    "ember-cli-test-loader": "0.2.0",
+    "ember-data": "2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "~2.1.4",
-    "loader.js": "3.2.1",
+    "loader.js": "3.3.0",
     "qunit": "~1.18.0"
   },
   "devDependencies": {
-    "fontawesome": "~4.3.0"
+    "fontawesome": "~4.4.0"
+  },
+  "resolutions": {
+    "ember": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,22 +28,22 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "ember-cli-app-version": "1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",
-    "ember-cli-release": "0.2.3",
+    "ember-cli-release": "0.2.6",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.8",
+    "ember-data": "2.0.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.7",
-    "ember-watson": "^0.5.0"
+    "ember-try": "0.0.8",
+    "ember-watson": "~0.6.4"
   },
   "keywords": [
     "ember-addon",
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "1.0.0",
     "ember-cli-sass": "dukex/ember-cli-sass#bugfix/addon-styles"
   },
   "ember-addon": {


### PR DESCRIPTION
Remove travis allowed failures to allow ember release/beta to be tested
